### PR TITLE
controller:  Wrap sequence numbers when they exceed 65535

### DIFF
--- a/pyremoteplay/controller.py
+++ b/pyremoteplay/controller.py
@@ -141,7 +141,7 @@ class Controller:
         self._session.stream.send_feedback(
             FeedbackHeader.Type.STATE, self._sequence_state, state=self.stick_state
         )
-        self._sequence_state += 1
+        self._sequence_state = (self._sequence_state + 1) % 0xFFFF
 
     def _send_event(self):
         """Send controller button event."""
@@ -151,7 +151,7 @@ class Controller:
         self._session.stream.send_feedback(
             FeedbackHeader.Type.EVENT, self._sequence_event, data=data
         )
-        self._sequence_event += 1
+        self._sequence_event = (self._sequence_event + 1) % 0xFFFF
 
     def _add_event_buffer(self, event: FeedbackEvent):
         """Append event to beginning of byte buffer.


### PR DESCRIPTION
Otherwise we enter a persistent error state where we keep on trying to pack numbers greater than 63335 into an unsigned int16

My controller polling rate must be much higher than ktnrg45?  My sessions die after a minute or two without this...