### PR TITLE
Use proper clipboard mode

### DIFF
--- a/pyremoteplay/gui/options.py
+++ b/pyremoteplay/gui/options.py
@@ -503,8 +503,8 @@ class OptionsWidget(QtWidgets.QWidget):
             "When you reach this page, copy the page URL and click 'Ok' to continue"
         )
         clipboard = QtWidgets.QApplication.clipboard()
-        clipboard.clear(mode=clipboard.Clipboard)
-        clipboard.setText(login_url, mode=clipboard.Clipboard)
+        clipboard.clear(mode=clipboard.Mode.Clipboard)
+        clipboard.setText(login_url, mode=clipboard.Mode.Clipboard)
         if not dialog.exec():
             return
 


### PR DESCRIPTION
The current mode callout causes "no such ……attribute" errors on recent PySide6 installs  (At least a fresh PySide6 install on Ubuntu 22.04)